### PR TITLE
[ci skip] README: use MarkDown as understood by topkg-care, fix travis link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-TypeBeat - Agnostic parser of the `Content-Type` in OCaml
-=========================================================
+## TypeBeat - Agnostic parser of the `Content-Type` in OCaml
 
-[![Build Status](https://travis-ci.org/oklm-wsh/TypeBeat.svg?branch=master)](https://travis-ci.org/oklm-wsh/TypeBeat)
+[![Build Status](https://travis-ci.org/mirage/typebeat.svg?branch=master)](https://travis-ci.org/mirage/typebeat)
 
 TypeBeat is a pure implementation of the parsing of the `Content-Type`'s value
 (see [RFC822](https://tools.ietf.org/html/rfc822) and


### PR DESCRIPTION
this leads to the following `topkg opam descr` (as used by `topkg opam pkg`):
```
Agnostic parser of the `Content-Type` in OCaml

[![Build Status](https://travis-ci.org/mirage/typebeat.svg?branch=master)](https://travis-ci.org/mirage/typebeat)

TypeBeat is a pure implementation of the parsing of the `Content-Type`'s value
(see [RFC822](https://tools.ietf.org/html/rfc822) and
[RFC2045](https://tools.ietf.org/html/rfc2045)). The reason of this *light*
library is to compute a complex rule. Indeed, it's __hard__ to parse the value
of the `Content-Type`, believe me.

So it's a common library if you want to know the value of the `Content-Type` and
don't worry, we respect the standard. We saved
the [IANA](https://www.iana.org/assignments/media-types/media-types.xhtml)
database too.
```

eariler, the entire README was put into `descr`.