### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/typebeat.opam
+++ b/typebeat.opam
@@ -15,7 +15,7 @@ build: [
 build-test: [["dune" "runtest" "-p" name "-j" jobs]]
 
 depends: [
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "angstrom" {>= "0.9.0"}
   "alcotest" {test}
 ]


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.